### PR TITLE
Запрос токена дает ошибку 404

### DIFF
--- a/lib/Api/AccessApi.php
+++ b/lib/Api/AccessApi.php
@@ -367,7 +367,7 @@ class AccessApi
 
         $query = \GuzzleHttp\Psr7\build_query($queryParams);
         return new Request(
-            'GET',
+            'POST',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
             $headers,
             $httpBody


### PR DESCRIPTION
GET метод не работает для получения токена. POST работает.